### PR TITLE
Add style guide and sort prodtype sections to 58 post

### DIFF
--- a/_posts/2021-09-30-release-0.1.58.md
+++ b/_posts/2021-09-30-release-0.1.58.md
@@ -126,7 +126,7 @@ More information can be found in the [development documentation](https://complia
 
 ### Style guide
 To help content developers we have created a [style guide](https://complianceascode.readthedocs.io/en/latest/manual/developer/04_style_guide.html).
-This document's goal is help ensure constancy across the codebase and help during the code review process.
-This document is living document, if you want add or change something please open an issue, or better yet a pull request.
+This document's goal is to help ensure constancy across the codebase and help during the code review process.
+This document is a living document, if you want to add or change something please open an issue, or better yet a pull request.
 
-You can full guide in the [development documentation](https://complianceascode.readthedocs.io/en/latest/manual/developer/04_style_guide.html)
+You can find the full guide in the [development documentation](https://complianceascode.readthedocs.io/en/latest/manual/developer/04_style_guide.html)

--- a/_posts/2021-09-30-release-0.1.58.md
+++ b/_posts/2021-09-30-release-0.1.58.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Releasing ComplianceAsCode / Content 0.1.58"
 categories: template
-author: Gabriel Becker, Marcus Burghardt, Watson Sato, Matěj Týč
+author: Gabriel Becker, Marcus Burghardt, Watson Sato, Matěj Týč, Matthew Burket
 ---
 
 With a bit more than one thousand commits since last release we are happy to announce that ComplianceAsCode / Content v0.1.58 was [released](https://github.com/ComplianceAsCode/content/releases/tag/v0.1.58) on September 24th, 2021.
@@ -83,6 +83,21 @@ $ PYTHONPATH=. utils/fix_rules.py --dry-run sort_subkeys  # This will check for 
 $ PYTHONPATH=. utils/fix_rules.py sort_subkeys  # This will sort any unsorted reference or identifier and ask for confirmation before writing to disk
 ```
 
+### Sorting of prodtype keys
+
+In similar vain to the previous section we also added sorting the `prodtype` key in `rule.yml`. 
+The `prodtype` key defines what products the rule applies to.
+
+
+All prodtypes were sorted in upstream and from now on any new addition needs to maintain it.
+Content developers can use `fix_rules.py` utility to check for issues and sort them:
+
+```
+$ PYTHONPATH=. utils/rule_dir_json.py  # that's a general prerequisite of fix_rules
+$ PYTHONPATH=. utils/fix_rules.py --dry-run sort_prodtypes  # This will check for rules with an unsorted prodtype key 
+$ PYTHONPATH=. utils/fix_rules.py sort_prodtypes  # This will sort any unsorted prodtype keys and ask for confirmation before writing to disk
+```
+
 ### Migration of the shared Bash remediations functions to Jinja macros
 
 Writing remediations is an important part of developing security content.
@@ -108,3 +123,10 @@ We have now an Ansible [role](https://galaxy.ansible.com/marcusburghardt/ansible
 This is a great option to start contributing faster, aligned with the official documentation while enjoying the automation benefits.
 
 More information can be found in the [development documentation](https://complianceascode.readthedocs.io/en/latest/manual/developer/02_building_complianceascode.html#fast-track).
+
+### Style guide
+To help content developers we have created a [style guide](https://complianceascode.readthedocs.io/en/latest/manual/developer/04_style_guide.html).
+This document's goal is help ensure constancy across the codebase and help during the code review process.
+This document is living document, if you want add or change something please open an issue, or better yet a pull request.
+
+You can full guide in the [development documentation](https://complianceascode.readthedocs.io/en/latest/manual/developer/04_style_guide.html)


### PR DESCRIPTION
This add a couple of sections to the 0.1.58 post:

- Style guide
- Sorting of prodtype keys

